### PR TITLE
Remove Apache Tika support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Pipeline completo para processamento de documentos PDF, DOCX e imagens, incluindo:
 
-- **Extração de Texto:** Diversas estratégias (PyPDFLoader, PDFMinerLoader, PDFMiner Low-Level, Unstructured, OCR para PDF, OCR para Imagens, PDFPlumber, Tika, PyMuPDF4LLM)
+- **Extração de Texto:** Diversas estratégias (PyPDFLoader, PDFMinerLoader, PDFMiner Low-Level, Unstructured, OCR para PDF, OCR para Imagens, PDFPlumber, PyMuPDF4LLM)
 - **Chunking Inteligente:** Filtragem de parágrafos, reconhecimento de headings, agrupamento, sliding window com overlap configurável e fallback para parágrafos longos
 - **Embeddings Vetoriais:** Suporte a múltiplos modelos (Ollama, Serafim-PT-IR, MPNet, MiniLM) com padding e truncation automáticos
 - **Indexação & Busca Híbrida (RAG):** PostgreSQL + pgvector usando tabelas dedicadas por dimensão
@@ -31,7 +31,6 @@ Pipeline completo para processamento de documentos PDF, DOCX e imagens, incluind
 - OCR Hybrid para PDF (pytesseract)
 - ImageOCR (PIL + pytesseract)
 - PDFPlumber
-- Apache Tika
 - PyMuPDF4LLM (Markdown)
 
 ### 2. Chunking Inteligente

--- a/extractors.py
+++ b/extractors.py
@@ -8,7 +8,6 @@ import fitz
 import pdfplumber
 import pytesseract
 from pdfminer.high_level import extract_text as pdfminer_extract_text
-from tika import parser
 from langchain_community.document_loaders import (
     PyPDFLoader,
     PDFMinerLoader,
@@ -84,10 +83,6 @@ class PDFPlumberStrategy:
         return "\n".join(texts)
 
 
-class TikaStrategy:
-    def extract(self, path: str) -> str:
-        result = parser.from_file(path)
-        return result.get("content", "") or ""
 
 
 class PyMuPDF4LLMStrategy:
@@ -120,7 +115,6 @@ STRATEGIES_MAP = {
     "unstructured": UnstructuredStrategy(),
     "ocr": OCRStrategy(),
     "plumber": PDFPlumberStrategy(),
-    "tika": TikaStrategy(),
     "pymupdf4llm": PyMuPDF4LLMStrategy(),
     "image": ImageOCRStrategy(),
 }
@@ -167,13 +161,6 @@ def extract_text(path: str, strategy: str) -> str:
     except Exception:
         pass
 
-    try:
-        parsed = parser.from_file(path)
-        txt = parsed.get("content", "") or ""
-        if len(txt.strip()) > OCR_THRESHOLD:
-            return txt
-    except Exception:
-        pass
 
     try:
         with pdfplumber.open(path) as pdf:

--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ start_metrics_server()
 # Opções de menu
 STRATEGY_OPTIONS = [
     "pypdf", "pdfminer", "pdfminer-low", "unstructured",
-    "ocr", "plumber", "tika", "pymupdf4llm"
+    "ocr", "plumber", "pymupdf4llm"
 ]
 EMBED_MODELS = {
     "1": OLLAMA_EMBEDDING_MODEL,

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ PyPDF2
 PyMuPDF
 python-docx
 pdfplumber
-tika
 unstructured
 pymupdf4llm
 


### PR DESCRIPTION
## Summary
- drop Apache Tika from dependencies
- remove Tika text extraction strategy and fallback
- update CLI options and documentation

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68433d3162c0832a8ac04e6241a95247