### PR TITLE
Add verbose logging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Todos os modelos e dimensões são configuráveis no arquivo `.env`.
 - Sair
 
 **Flags:**
-- `--verbose`: logs detalhados
+- `--verbose`: ativa logs em nível DEBUG
 
 **Progresso:** `tqdm` com `set_postfix` para processados/erros
 
@@ -217,6 +217,7 @@ Execute o DDL completo para criar tabelas, dicionários, configuração FTS, tri
 ## Executando o CLI
 
 ```bash
+# Use --verbose para habilitar logs em nível DEBUG
 python3 main.py [--verbose]
 ```
 

--- a/main.py
+++ b/main.py
@@ -23,9 +23,8 @@ from constants import VALID_EXTS
 from pg_storage import save_to_postgres
 from metrics import start_metrics_server
 
-# Valida configuração e inicializa logs e métricas
+# Valida configuração e inicia métricas
 validate_config()
-setup_logging()
 start_metrics_server()
 
 # Opções de menu
@@ -160,6 +159,8 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--verbose", action="store_true")
     args = parser.parse_args()
+
+    setup_logging(args.verbose)
 
     strat = "ocr"
     model = OLLAMA_EMBEDDING_MODEL

--- a/utils.py
+++ b/utils.py
@@ -13,8 +13,10 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from config import CHUNK_SIZE, CHUNK_OVERLAP, SEPARATORS
 from constants import VALID_EXTS
 
-def setup_logging():
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+def setup_logging(verbose: bool = False) -> None:
+    """Configure basic logging level."""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format='%(asctime)s - %(levelname)s - %(message)s')
 
 def build_record(path: str, text: str) -> dict:
     try:


### PR DESCRIPTION
## Summary
- add optional verbose flag to `setup_logging`
- configure logging level in `main` using CLI flag
- document verbose flag in README

## Testing
- `python -m py_compile *.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685039659a74832a956d99d204012e50