### PR TITLE
Fix Processado folder casing in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Pipeline completo para processamento de documentos PDF, DOCX e imagens, incluind
 - **Re-ranking:** Cross-Encoder (ms-marco) para maior precisão
 - **Monitoramento:** Prometheus (latência, contagem de buscas, tamanho dos resultados)
 - **CLI Interativo:** Seleção de estratégia, modelo, dimensão **e dispositivo (cpu/gpu/auto)**, modo verboso, processamento em lote com barra de progresso e estatísticas em tempo real
- - **Organização:** Arquivos processados são movidos para a subpasta `processado`,
+ - **Organização:** Arquivos processados são movidos para a subpasta `Processado`,
    que é ignorada em execuções futuras
 
 ---
@@ -91,7 +91,7 @@ Todos os modelos e dimensões são configuráveis no arquivo `.env`.
 - Selecionar Dimensão
 - Selecionar Dispositivo (CPU/GPU/Auto)
 - Processar Arquivo / Pasta (inclui imagens)
- - Mover arquivos concluídos para a subpasta `processado` (essa pasta é ignorada ao processar pastas)
+ - Mover arquivos concluídos para a subpasta `Processado` (essa pasta é ignorada ao processar pastas)
 - Sair
 
 **Flags:**


### PR DESCRIPTION
## Summary
- sync README with code by using capitalized `Processado`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68503a200c54832aa38c6ebeb4e26856