### PR TITLE
Use placeholder for API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,11 @@ pip install -r requirements.txt
 ---
 
 ## Exemplo de `.env`
+Substitua `YOUR_NVD_API_KEY` pela chave obtida no portal da NVD.
 
 ```env
 # NVD API Key (para incremental)
-NVD_API_KEY=98dbb4f5-7540-4ca1-ae81-ffabf4b076b6
+NVD_API_KEY=YOUR_NVD_API_KEY
 
 # PostgreSQL Connection
 PG_HOST=172.16.187.133

--- a/exemplo.env
+++ b/exemplo.env
@@ -2,7 +2,7 @@
 # .env example
 # =====================================================================
 # — NVD API Key (para incremental)
-NVD_API_KEY=98dbb4f5-7540-4ca1-ae81-ffabf4b076b6
+NVD_API_KEY=YOUR_NVD_API_KEY
 
 # — PostgreSQL Connection
 PG_HOST=192.168.3.32


### PR DESCRIPTION
## Summary
- remove concrete NVD API key
- note that users must set `YOUR_NVD_API_KEY` in `.env` example

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68503a9cc810832aa957ec49fe7167b4